### PR TITLE
Standalone player shop fixes

### DIFF
--- a/media/lua/client/ISEditPlayerShopUI.lua
+++ b/media/lua/client/ISEditPlayerShopUI.lua
@@ -267,7 +267,10 @@ function ISEditPlayerShopUI:onOptionMouseDown(button, x, y)
           itemPrices[GetFullType(v.item)] = '0'
         end
       else
-        if tonumber(price) < 0 then
+        if tonumber(price) > 0 then
+          print('added to sellItems')
+          sellItems[GetFullType(v.item)] = tostring(tonumber(price) * -1)
+        elseif tonumber(price) < 0 then
           print('added to sellItems')
           sellItems[GetFullType(v.item)] = price
         end

--- a/media/lua/client/PlayerShops.lua
+++ b/media/lua/client/PlayerShops.lua
@@ -20,7 +20,7 @@ local function onCreateShop(object, player)
   square:transmitRemoveItemFromSquare(object)
   local properties = object:getProperties()
   local newObject = IsoThumpable.new(object:getCell(), square, object:getSprite():getName(), properties:Is("collideN"), nil)
-  newObject:setCanBeLockByPadlock(true)
+  newObject:setCanBeLockByPadlock(getActivatedMods():contains('ZZZZAlbionPlayerShops_ModCompat'))
   newObject:setBlockAllTheSquare(properties:Is("collideN") and properties:Is("collideW"))
   newObject:setIsThumpable(properties:Is("collideN") or properties:Is("collideW"))
   newObject:setThumpDmg(0)
@@ -60,6 +60,13 @@ local function OnPreFillWorldObjectContextMenu(player, context, worldObjects, te
         end
         --view store
         local shopOption = context:addOption("View Store", v, onViewShop, shopData)
+          if not getActivatedMods():contains('ZZZZAlbionPlayerShops_ModCompat') and __PlayerShopsRestrictions.hasAccessToShop(v, playerObj) then
+            if v:isLockedByPadlock() then
+              local unlockOption = context:addOption("Unlock", v, __PlayerShopsRestrictions.lockUnlockPlayerShop, v, false);
+            else
+              local lockOption = context:addOption("Lock", v, __PlayerShopsRestrictions.lockUnlockPlayerShop, v, true);
+            end
+          end
         break
       elseif hasLedger then
         --convert to shop
@@ -172,6 +179,13 @@ __PlayerShopsRestrictions.hasAccessToShop = function(obj, player)
     if isAdmin() then return true end
     local username = player:getUsername()
     return shopData.owner == username or shopData.coowners[username]
+end
+
+---@param worldobjects
+---@param object IsoObject
+---@param locked bool
+__PlayerShopsRestrictions.lockUnlockPlayerShop = function(worldobjects, object, locked)
+    object:setLockedByPadlock(locked);
 end
 
 ---@deprecated


### PR DESCRIPTION
- Added restrictions of destroy, dismantle and pickup when compatibility mod is disabled
- Disabled option to install padlock and added lock/unlock context menu without need of key when compatibility mod is disabled
- Buy orders are working, but price has to be set negative - add QOL that when BO is saved with positive value, it becomes negative

version for test:
https://steamcommunity.com/sharedfiles/filedetails/?id=3308276118